### PR TITLE
feat(organization controller): 팔로우 관련 organization 컨트롤러 테스트

### DIFF
--- a/potato-api/src/test/java/com/potato/controller/organization/OrganizationMockMvc.java
+++ b/potato-api/src/test/java/com/potato/controller/organization/OrganizationMockMvc.java
@@ -3,6 +3,7 @@ package com.potato.controller.organization;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.potato.controller.ApiResponse;
+import com.potato.service.member.dto.response.MemberInfoResponse;
 import com.potato.service.organization.dto.request.CreateOrganizationRequest;
 import com.potato.service.organization.dto.response.OrganizationInfoResponse;
 import com.potato.service.organization.dto.response.OrganizationWithMembersInfoResponse;
@@ -108,6 +109,61 @@ class OrganizationMockMvc {
 
     public ApiResponse<String> leaveFromOrganization(String subDomain, String token) throws Exception {
         MockHttpServletRequestBuilder builder = delete("/api/v1/organization/leave/" + subDomain)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ".concat(token));
+
+        return objectMapper.readValue(
+            mockMvc.perform(builder)
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8), new TypeReference<>() {
+            }
+        );
+    }
+
+    public ApiResponse<String> followOrganization(String subDomain, String token) throws Exception {
+        MockHttpServletRequestBuilder builder = post("/api/v1/organization/follow/" + subDomain)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ".concat(token));
+
+        return objectMapper.readValue(
+            mockMvc.perform(builder)
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8), new TypeReference<>() {
+            }
+        );
+    }
+
+    public ApiResponse<String> unFollowOrganization(String subDomain, String token) throws Exception {
+        MockHttpServletRequestBuilder builder = delete("/api/v1/organization/follow/" + subDomain)
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ".concat(token));
+
+        return objectMapper.readValue(
+            mockMvc.perform(builder)
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8), new TypeReference<>() {
+            }
+        );
+    }
+
+    public ApiResponse<List<MemberInfoResponse>> getOrganizationFollowMember(String subDomain) throws Exception {
+        MockHttpServletRequestBuilder builder = get("/api/v1/organization/follow/" + subDomain)
+            .contentType(MediaType.APPLICATION_JSON);
+
+        return objectMapper.readValue(
+            mockMvc.perform(builder)
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8), new TypeReference<>() {
+            }
+        );
+    }
+
+    public ApiResponse<List<OrganizationInfoResponse>> retrieveFollowingOrganization(String token) throws Exception {
+        MockHttpServletRequestBuilder builder = get("/api/v1/member/organization/follow")
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, "Bearer ".concat(token));
 


### PR DESCRIPTION
특정 조직 팔로우, 언팔로우, 그룹을 팔로우한 멤버리스트, 멤버가 팔로우한 그룹들 - 컨트롤러 테스트 
혹시 response의 정보들 다 확인하는게 좋을까요?