### PR TITLE
[POTATO-17] 게시글에 해당하는 해시태그 기능 추가.

### DIFF
--- a/potato-api/http/board/board.http
+++ b/potato-api/http/board/board.http
@@ -9,7 +9,8 @@ Authorization: Bearer {{AUTHORIZATION}}
     "startDateTime": "2021-05-01T00:00:00",
     "endDateTime": "2021-05-08T11:59:59",
     "imageUrl": "https://avatars.githubusercontent.com/u/48153675?v=4",
-    "type": "EVENT"
+    "type": "EVENT",
+    "hashTags": ["감자", "고구마"]
 }
 
 ### 특정 그룹의 게시물을 조회하는 API
@@ -30,7 +31,8 @@ Authorization: Bearer {{AUTHORIZATION}}
     "startDateTime": "2021-03-05T00:00:00",
     "endDateTime": "2021-03-13T11:59:59",
     "imageUrl": "http://image.url",
-    "type": "RECRUIT"
+    "type": "RECRUIT",
+    "hashTags": ["백엔드"]
 }
 
 ### 게시물의 좋아요를 추가하는 API

--- a/potato-api/src/main/java/com/potato/controller/hashtag/HashTagEventListener.java
+++ b/potato-api/src/main/java/com/potato/controller/hashtag/HashTagEventListener.java
@@ -1,0 +1,26 @@
+package com.potato.controller.hashtag;
+
+import com.potato.event.board.BoardCreatedEvent;
+import com.potato.event.board.BoardUpdatedEvent;
+import com.potato.service.hashtag.BoardHashTagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class HashTagEventListener {
+
+    private final BoardHashTagService boardHashTagService;
+
+    @EventListener
+    public void addNewBoardHashTags(BoardCreatedEvent event) {
+        boardHashTagService.addHashTag(event.getType(), event.getBoardId(), event.getCreatorId(), event.getHashTags());
+    }
+
+    @EventListener
+    public void updateBoardHashTags(BoardUpdatedEvent event) {
+        boardHashTagService.updateHashTags(event.getType(), event.getBoardId(), event.getCreatorId(), event.getHashTags());
+    }
+
+}

--- a/potato-api/src/main/java/com/potato/event/board/BoardCreatedEvent.java
+++ b/potato-api/src/main/java/com/potato/event/board/BoardCreatedEvent.java
@@ -1,0 +1,31 @@
+package com.potato.event.board;
+
+import com.potato.domain.board.BoardType;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class BoardCreatedEvent {
+
+    private final BoardType type;
+
+    private final Long boardId;
+
+    private final Long creatorId;
+
+    private final List<String> hashTags = new ArrayList<>();
+
+    private BoardCreatedEvent(BoardType type, Long boardId, Long creatorId, List<String> hashTags) {
+        this.type = type;
+        this.boardId = boardId;
+        this.creatorId = creatorId;
+        this.hashTags.addAll(hashTags);
+    }
+
+    public static BoardCreatedEvent of(BoardType type, Long boardId, Long creatorId, List<String> hashTags) {
+        return new BoardCreatedEvent(type, boardId, creatorId, hashTags);
+    }
+
+}

--- a/potato-api/src/main/java/com/potato/event/board/BoardUpdatedEvent.java
+++ b/potato-api/src/main/java/com/potato/event/board/BoardUpdatedEvent.java
@@ -1,0 +1,31 @@
+package com.potato.event.board;
+
+import com.potato.domain.board.BoardType;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class BoardUpdatedEvent {
+
+    private final BoardType type;
+
+    private final Long boardId;
+
+    private final Long creatorId;
+
+    private final List<String> hashTags = new ArrayList<>();
+
+    public BoardUpdatedEvent(BoardType type, Long boardId, Long creatorId, List<String> hashTags) {
+        this.type = type;
+        this.boardId = boardId;
+        this.creatorId = creatorId;
+        this.hashTags.addAll(hashTags);
+    }
+
+    public static BoardUpdatedEvent of(BoardType type, Long boardId, Long creatorId, List<String> hashTags) {
+        return new BoardUpdatedEvent(type, boardId, creatorId, hashTags);
+    }
+
+}

--- a/potato-api/src/main/java/com/potato/service/board/organization/OrganizationBoardRetrieveService.java
+++ b/potato-api/src/main/java/com/potato/service/board/organization/OrganizationBoardRetrieveService.java
@@ -1,9 +1,12 @@
 package com.potato.service.board.organization;
 
+import com.potato.domain.board.BoardType;
 import com.potato.domain.board.organization.OrganizationBoard;
 import com.potato.domain.board.organization.OrganizationBoardRepository;
 import com.potato.domain.board.organization.OrganizationBoardCategory;
 import com.potato.domain.board.organization.repository.dto.BoardWithOrganizationDto;
+import com.potato.domain.hashtag.BoardHashTag;
+import com.potato.domain.hashtag.BoardHashTagRepository;
 import com.potato.domain.member.Member;
 import com.potato.domain.member.MemberRepository;
 import com.potato.domain.organization.Organization;
@@ -11,6 +14,7 @@ import com.potato.domain.organization.OrganizationRepository;
 import com.potato.service.board.organization.dto.request.RetrieveImminentBoardsRequest;
 import com.potato.service.board.organization.dto.response.OrganizationBoardInfoResponse;
 import com.potato.service.board.organization.dto.response.OrganizationBoardWithCreatorInfoResponse;
+import com.potato.service.hashtag.BoardHashTagServiceUtils;
 import com.potato.service.member.MemberServiceUtils;
 import com.potato.service.organization.OrganizationServiceUtils;
 import lombok.RequiredArgsConstructor;
@@ -27,13 +31,21 @@ public class OrganizationBoardRetrieveService {
     private final OrganizationBoardRepository organizationBoardRepository;
     private final OrganizationRepository organizationRepository;
     private final MemberRepository memberRepository;
+    private final BoardHashTagRepository boardHashTagRepository;
 
     @Transactional(readOnly = true)
     public OrganizationBoardWithCreatorInfoResponse retrieveBoardWithOrganizationAndCreator(Long organizationBoardId) {
         OrganizationBoard organizationBoard = OrganizationBoardServiceUtils.findOrganizationBoardById(organizationBoardRepository, organizationBoardId);
         Organization organization = OrganizationServiceUtils.findOrganizationBySubDomain(organizationRepository, organizationBoard.getSubDomain());
         Member creator = MemberServiceUtils.findMemberById(memberRepository, organizationBoard.getMemberId());
-        return OrganizationBoardWithCreatorInfoResponse.of(organizationBoard, organization, creator);
+        return OrganizationBoardWithCreatorInfoResponse.of(organizationBoard, organization, creator, getBoardHashTags(organizationBoard.getId()));
+    }
+
+    private List<String> getBoardHashTags(Long boardId) {
+        List<BoardHashTag> boardHashTags = BoardHashTagServiceUtils.findBoardHashTags(boardHashTagRepository, boardId, BoardType.ORGANIZATION_BOARD);
+        return boardHashTags.stream()
+            .map(BoardHashTag::getHashTag)
+            .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)

--- a/potato-api/src/main/java/com/potato/service/board/organization/dto/request/CreateOrganizationBoardRequest.java
+++ b/potato-api/src/main/java/com/potato/service/board/organization/dto/request/CreateOrganizationBoardRequest.java
@@ -8,6 +8,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @ToString
 @Getter
@@ -33,14 +34,19 @@ public class CreateOrganizationBoardRequest {
     @NotNull
     private OrganizationBoardCategory type;
 
+    @NotNull
+    private List<String> hashTags;
+
     @Builder(builderMethodName = "testBuilder")
-    public CreateOrganizationBoardRequest(String title, String content, String imageUrl, LocalDateTime startDateTime, LocalDateTime endDateTime, OrganizationBoardCategory type) {
+    public CreateOrganizationBoardRequest(String title, String content, String imageUrl, LocalDateTime startDateTime,
+                                          LocalDateTime endDateTime, OrganizationBoardCategory type, List<String> hashTags) {
         this.title = title;
         this.content = content;
         this.imageUrl = imageUrl;
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.type = type;
+        this.hashTags = hashTags;
     }
 
     public OrganizationBoard toEntity(String subDomain, Long memberId) {

--- a/potato-api/src/main/java/com/potato/service/board/organization/dto/request/UpdateOrganizationBoardRequest.java
+++ b/potato-api/src/main/java/com/potato/service/board/organization/dto/request/UpdateOrganizationBoardRequest.java
@@ -7,6 +7,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @ToString
 @Getter
@@ -34,8 +35,12 @@ public class UpdateOrganizationBoardRequest {
     @NotNull
     private OrganizationBoardCategory type;
 
+    @NotNull
+    private List<String> hashTags;
+
     @Builder(builderMethodName = "testBuilder")
-    public UpdateOrganizationBoardRequest(Long organizationBoardId, String title, String content, String imageUrl, LocalDateTime startDateTime, LocalDateTime endDateTime, OrganizationBoardCategory type) {
+    public UpdateOrganizationBoardRequest(Long organizationBoardId, String title, String content, String imageUrl,
+                                          LocalDateTime startDateTime, LocalDateTime endDateTime, OrganizationBoardCategory type, List<String> hashTags) {
         this.organizationBoardId = organizationBoardId;
         this.title = title;
         this.content = content;
@@ -43,6 +48,7 @@ public class UpdateOrganizationBoardRequest {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.type = type;
+        this.hashTags = hashTags;
     }
 
 }

--- a/potato-api/src/main/java/com/potato/service/board/organization/dto/response/OrganizationBoardWithCreatorInfoResponse.java
+++ b/potato-api/src/main/java/com/potato/service/board/organization/dto/response/OrganizationBoardWithCreatorInfoResponse.java
@@ -7,6 +7,8 @@ import com.potato.service.member.dto.response.MemberInfoResponse;
 import com.potato.service.organization.dto.response.OrganizationInfoResponse;
 import lombok.*;
 
+import java.util.List;
+
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -19,9 +21,11 @@ public class OrganizationBoardWithCreatorInfoResponse {
 
     private MemberInfoResponse creator;
 
-    public static OrganizationBoardWithCreatorInfoResponse of(OrganizationBoard organizationBoard, Organization organization, Member creator) {
+    private List<String> hashTags;
+
+    public static OrganizationBoardWithCreatorInfoResponse of(OrganizationBoard organizationBoard, Organization organization, Member creator, List<String> hashTags) {
         return new OrganizationBoardWithCreatorInfoResponse(OrganizationBoardInfoResponse.of(organizationBoard),
-            OrganizationInfoResponse.of(organization), MemberInfoResponse.of(creator));
+            OrganizationInfoResponse.of(organization), MemberInfoResponse.of(creator), hashTags);
     }
 
 }

--- a/potato-api/src/main/java/com/potato/service/hashtag/BoardHashTagService.java
+++ b/potato-api/src/main/java/com/potato/service/hashtag/BoardHashTagService.java
@@ -1,0 +1,35 @@
+package com.potato.service.hashtag;
+
+import com.potato.domain.board.BoardType;
+import com.potato.domain.hashtag.BoardHashTag;
+import com.potato.domain.hashtag.BoardHashTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class BoardHashTagService {
+
+    private final BoardHashTagRepository boardHashTagRepository;
+
+    @Transactional
+    public void addHashTag(BoardType type, Long boardId, Long memberId, List<String> hashTags) {
+        List<BoardHashTag> boardHashTags = hashTags.stream()
+            .distinct()
+            .map(hashTag -> BoardHashTag.newInstance(type, boardId, memberId, hashTag))
+            .collect(Collectors.toList());
+        boardHashTagRepository.saveAll(boardHashTags);
+    }
+
+    @Transactional
+    public void updateHashTags(BoardType type, Long boardId, Long memberId, List<String> hashTags) {
+        List<BoardHashTag> hashTagList = BoardHashTagServiceUtils.findBoardHashTags(boardHashTagRepository, boardId, type);
+        boardHashTagRepository.deleteAll(hashTagList);
+        addHashTag(type, boardId, memberId, hashTags);
+    }
+
+}

--- a/potato-api/src/main/java/com/potato/service/hashtag/BoardHashTagServiceUtils.java
+++ b/potato-api/src/main/java/com/potato/service/hashtag/BoardHashTagServiceUtils.java
@@ -1,0 +1,18 @@
+package com.potato.service.hashtag;
+
+import com.potato.domain.board.BoardType;
+import com.potato.domain.hashtag.BoardHashTag;
+import com.potato.domain.hashtag.BoardHashTagRepository;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BoardHashTagServiceUtils {
+
+    public static List<BoardHashTag> findBoardHashTags(BoardHashTagRepository boardHashTagRepository, Long boardId, BoardType type) {
+        return boardHashTagRepository.findAllByTypeAndBoardId(boardId, type);
+    }
+
+}

--- a/potato-api/src/test/java/com/potato/controller/board/OrganizationBoardControllerTest.java
+++ b/potato-api/src/test/java/com/potato/controller/board/OrganizationBoardControllerTest.java
@@ -2,11 +2,14 @@ package com.potato.controller.board;
 
 import com.potato.controller.ApiResponse;
 import com.potato.controller.ControllerTestUtils;
+import com.potato.domain.board.BoardType;
 import com.potato.domain.board.organization.OrganizationBoard;
 import com.potato.domain.board.organization.OrganizationBoardCategory;
 import com.potato.domain.board.organization.OrganizationBoardCreator;
 import com.potato.domain.board.organization.OrganizationBoardRepository;
 import com.potato.domain.board.organization.repository.dto.BoardWithOrganizationDto;
+import com.potato.domain.hashtag.BoardHashTag;
+import com.potato.domain.hashtag.BoardHashTagRepository;
 import com.potato.domain.member.Member;
 import com.potato.domain.organization.Organization;
 import com.potato.domain.organization.OrganizationCreator;
@@ -24,6 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +44,9 @@ class OrganizationBoardControllerTest extends ControllerTestUtils {
     @Autowired
     private OrganizationRepository organizationRepository;
 
+    @Autowired
+    private BoardHashTagRepository boardHashTagRepository;
+
     @BeforeEach
     void setUp() {
         super.setup();
@@ -51,6 +58,7 @@ class OrganizationBoardControllerTest extends ControllerTestUtils {
         super.cleanup();
         organizationBoardRepository.deleteAll();
         organizationRepository.deleteAll();
+        boardHashTagRepository.deleteAll();
     }
 
     @Test
@@ -75,6 +83,7 @@ class OrganizationBoardControllerTest extends ControllerTestUtils {
             .startDateTime(startTime)
             .endDateTime(endTime)
             .type(OrganizationBoardCategory.RECRUIT)
+            .hashTags(Arrays.asList("감자", "고구마"))
             .build();
 
         //when
@@ -100,6 +109,8 @@ class OrganizationBoardControllerTest extends ControllerTestUtils {
         OrganizationBoard board = OrganizationBoardCreator.create(subDomain, testMember.getId(), title, OrganizationBoardCategory.RECRUIT);
         organizationBoardRepository.save(board);
 
+        boardHashTagRepository.saveAll(Collections.singletonList(BoardHashTag.newInstance(BoardType.ORGANIZATION_BOARD, board.getId(), testMember.getId(), "감자")));
+
         //when
         ApiResponse<OrganizationBoardWithCreatorInfoResponse> response = organizationBoardMockMvc.retrieveOrganizationBoard(board.getId(), 200);
 
@@ -107,6 +118,7 @@ class OrganizationBoardControllerTest extends ControllerTestUtils {
         assertThat(response.getData().getBoard().getTitle()).isEqualTo(title);
         assertThat(response.getData().getCreator().getEmail()).isEqualTo(testMember.getEmail());
         assertThat(response.getData().getOrganization().getSubDomain()).isEqualTo(subDomain);
+        assertThat(response.getData().getHashTags()).isEqualTo(Collections.singletonList("감자"));
     }
 
     @Test
@@ -192,6 +204,7 @@ class OrganizationBoardControllerTest extends ControllerTestUtils {
             .startDateTime(LocalDateTime.of(2021, 3, 30, 0, 0))
             .endDateTime(LocalDateTime.of(2021, 3, 31, 0, 0))
             .type(OrganizationBoardCategory.RECRUIT)
+            .hashTags(Collections.emptyList())
             .build();
 
         //when

--- a/potato-api/src/test/java/com/potato/service/hashtag/HashTagServiceTest.java
+++ b/potato-api/src/test/java/com/potato/service/hashtag/HashTagServiceTest.java
@@ -1,0 +1,91 @@
+package com.potato.service.hashtag;
+
+import com.potato.domain.board.BoardType;
+import com.potato.domain.hashtag.BoardHashTag;
+import com.potato.domain.hashtag.BoardHashTagRepository;
+import com.potato.service.OrganizationMemberSetUpTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class HashTagServiceTest extends OrganizationMemberSetUpTest {
+
+    @Autowired
+    private BoardHashTagService boardHashTagService;
+
+    @Autowired
+    private BoardHashTagRepository boardHashTagRepository;
+
+    @AfterEach
+    void cleanUp() {
+        super.cleanup();
+        boardHashTagRepository.deleteAll();
+    }
+
+    @Test
+    void 특정_게시뭃에_해당하는_해시태그들을_저장한다() {
+        // given
+        Long boardId = 100L;
+        List<String> hashTags = Arrays.asList("감자", "백엔드", "화이팅");
+
+        // when
+        boardHashTagService.addHashTag(BoardType.ORGANIZATION_BOARD, boardId, memberId, hashTags);
+
+        // then
+        List<BoardHashTag> hashTagList = boardHashTagRepository.findAll();
+        assertThat(hashTagList).hasSize(3);
+        assertHashTag(hashTagList.get(0), boardId, memberId, "감자");
+        assertHashTag(hashTagList.get(1), boardId, memberId, "백엔드");
+        assertHashTag(hashTagList.get(2), boardId, memberId, "화이팅");
+    }
+
+    @Test
+    void 해시태그_저장시_중복된_해시태그가_있을경우_제거하고_저장한다() {
+        // given
+        String hashTag = "감자";
+        Long boardId = 100L;
+        List<String> hashTags = Arrays.asList(hashTag, hashTag, hashTag);
+
+        // when
+        boardHashTagService.addHashTag(BoardType.ORGANIZATION_BOARD, boardId, memberId, hashTags);
+
+        // then
+        List<BoardHashTag> hashTagList = boardHashTagRepository.findAll();
+        assertThat(hashTagList).hasSize(1);
+        assertHashTag(hashTagList.get(0), boardId, memberId, hashTag);
+    }
+
+    @Test
+    void 해시태그를_수정하면_기존의_해시태그가_제거되고_새로운_해시태그가_저장된다() {
+        // given
+        String hashTags1 = "백엔드";
+        String hashTags2 = "프론트";
+
+        BoardType type = BoardType.ORGANIZATION_BOARD;
+        Long boardId = 100L;
+        boardHashTagRepository.save(BoardHashTag.newInstance(type, boardId, memberId, "감자"));
+
+        // when
+        boardHashTagService.updateHashTags(type, boardId, memberId, Arrays.asList(hashTags1, hashTags2));
+
+        // then
+        List<BoardHashTag> hashTagList = boardHashTagRepository.findAll();
+        assertThat(hashTagList).hasSize(2);
+        assertHashTag(hashTagList.get(0), boardId, memberId, hashTags1);
+        assertHashTag(hashTagList.get(1), boardId, memberId, hashTags2);
+    }
+
+    private void assertHashTag(BoardHashTag boardHashTag, Long boardId, Long memberId, String hashtag) {
+        assertThat(boardHashTag.getBoardId()).isEqualTo(boardId);
+        assertThat(boardHashTag.getMemberId()).isEqualTo(memberId);
+        assertThat(boardHashTag.getHashTag()).isEqualTo(hashtag);
+    }
+
+}

--- a/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTag.java
+++ b/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTag.java
@@ -1,0 +1,33 @@
+package com.potato.domain.hashtag;
+
+import com.potato.domain.BaseTimeEntity;
+import com.potato.domain.board.BoardType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class BoardHashTag extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 30)
+    @Enumerated(EnumType.STRING)
+    private BoardType type;
+
+    @Column(nullable = false)
+    private Long boardId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private String hashTag;
+
+}

--- a/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTag.java
+++ b/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTag.java
@@ -30,4 +30,15 @@ public class BoardHashTag extends BaseTimeEntity {
     @Column(nullable = false)
     private String hashTag;
 
+    private BoardHashTag(BoardType type, Long boardId, Long memberId, String hashTag) {
+        this.type = type;
+        this.boardId = boardId;
+        this.memberId = memberId;
+        this.hashTag = hashTag;
+    }
+
+    public static BoardHashTag newInstance(BoardType type, Long boardId, Long memberId, String hashTag) {
+        return new BoardHashTag(type, boardId, memberId, hashTag);
+    }
+
 }

--- a/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTag.java
+++ b/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTag.java
@@ -11,6 +11,9 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(indexes = {
+    @Index(name = "idx_board_hash_tag_1", columnList = "boardId,type")
+})
 public class BoardHashTag extends BaseTimeEntity {
 
     @Id
@@ -27,7 +30,7 @@ public class BoardHashTag extends BaseTimeEntity {
     @Column(nullable = false)
     private Long memberId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String hashTag;
 
     private BoardHashTag(BoardType type, Long boardId, Long memberId, String hashTag) {

--- a/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTagRepository.java
+++ b/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTagRepository.java
@@ -1,0 +1,7 @@
+package com.potato.domain.hashtag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardHashTagRepository extends JpaRepository<BoardHashTag, Long> {
+
+}

--- a/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTagRepository.java
+++ b/potato-domain/src/main/java/com/potato/domain/hashtag/BoardHashTagRepository.java
@@ -1,7 +1,8 @@
 package com.potato.domain.hashtag;
 
+import com.potato.domain.hashtag.repository.BoardHashTagRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BoardHashTagRepository extends JpaRepository<BoardHashTag, Long> {
+public interface BoardHashTagRepository extends JpaRepository<BoardHashTag, Long>, BoardHashTagRepositoryCustom {
 
 }

--- a/potato-domain/src/main/java/com/potato/domain/hashtag/repository/BoardHashTagRepositoryCustom.java
+++ b/potato-domain/src/main/java/com/potato/domain/hashtag/repository/BoardHashTagRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.potato.domain.hashtag.repository;
+
+import com.potato.domain.board.BoardType;
+import com.potato.domain.hashtag.BoardHashTag;
+
+import java.util.List;
+
+public interface BoardHashTagRepositoryCustom {
+
+    List<BoardHashTag> findAllByTypeAndBoardId(Long boardId, BoardType type);
+
+}

--- a/potato-domain/src/main/java/com/potato/domain/hashtag/repository/BoardHashTagRepositoryCustomImpl.java
+++ b/potato-domain/src/main/java/com/potato/domain/hashtag/repository/BoardHashTagRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package com.potato.domain.hashtag.repository;
+
+import com.potato.domain.board.BoardType;
+import com.potato.domain.hashtag.BoardHashTag;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.potato.domain.hashtag.QBoardHashTag.boardHashTag;
+
+@RequiredArgsConstructor
+public class BoardHashTagRepositoryCustomImpl implements BoardHashTagRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<BoardHashTag> findAllByTypeAndBoardId(Long boardId, BoardType type) {
+        return queryFactory.selectFrom(boardHashTag)
+            .where(
+                boardHashTag.boardId.eq(boardId),
+                boardHashTag.type.eq(type)
+            ).fetch();
+    }
+
+}

--- a/potato-domain/src/main/resources/db/migration/V4__boardhashtag__create.sql
+++ b/potato-domain/src/main/resources/db/migration/V4__boardhashtag__create.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `board_hash_tag`
+(
+    `id`                      BIGINT      NOT NULL AUTO_INCREMENT,
+    `type`                    VARCHAR(30) NOT NULL,
+    `board_id`                BIGINT      NOT NULL,
+    `member_id`               BIGINT      NOT NULL,
+    `hash_tag`                VARCHAR(50) NOT NULL,
+    `created_date_time`       DATETIME(6) DEFAULT NULL,
+    `last_modified_date_time` DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_board_hash_tag_1` (`board_id`, `type`)
+) ENGINE = InnoDB;


### PR DESCRIPTION
- [x] 관리자 게시글, 그룹 게시글 등 모든 게시글의 해시태그를 관리할 수 있도록 함.
- [x] 현재는 그룹 게시글만 해시태그 기능을 추가해둔 상황. 