### PR TITLE
[POTATO-33] 그룹, 그룹 게시물, 댓글 조회시 팔로우, 좋아요 여부 필드 포함 (비 로그인 허용)

### DIFF
--- a/potato-api/http/member/member.http
+++ b/potato-api/http/member/member.http
@@ -3,7 +3,7 @@ POST {{host_api}}/api/v1/member
 Content-Type: application/json
 
 {
-    "email": "wil123133l.seungho@gmail.com",
+    "email": "potato@gmail.com",
     "name": "강승호",
     "profileUrl": "https://avatars.githubusercontent.com/u/48153675?v=4",
     "major": "IT_ICT",

--- a/potato-api/src/main/java/com/potato/api/config/interceptor/auth/Auth.java
+++ b/potato-api/src/main/java/com/potato/api/config/interceptor/auth/Auth.java
@@ -12,6 +12,7 @@ public @interface Auth {
     Role role() default Role.USER;
 
     enum Role {
+        OPTIONAL_LOGIN,
         USER,
         ORGANIZATION_MEMBER,
         ORGANIZATION_ADMIN

--- a/potato-api/src/main/java/com/potato/api/config/interceptor/auth/AuthInterceptor.java
+++ b/potato-api/src/main/java/com/potato/api/config/interceptor/auth/AuthInterceptor.java
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static com.potato.api.config.interceptor.auth.Auth.Role.OPTIONAL_LOGIN;
 import static com.potato.api.config.interceptor.auth.Auth.Role.ORGANIZATION_ADMIN;
 import static com.potato.api.config.interceptor.auth.Auth.Role.ORGANIZATION_MEMBER;
 
@@ -31,6 +32,13 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
         if (auth == null) {
             return true;
         }
+
+        if (auth.role().compareTo(OPTIONAL_LOGIN) == 0) {
+            Long memberId = loginUserComponent.getMemberIdIfExists(request);
+            request.setAttribute(MEMBER_ID, memberId);
+            return true;
+        }
+
         Long memberId = loginUserComponent.getMemberId(request);
         request.setAttribute(MEMBER_ID, memberId);
 

--- a/potato-api/src/main/java/com/potato/api/config/interceptor/auth/LoginUserComponent.java
+++ b/potato-api/src/main/java/com/potato/api/config/interceptor/auth/LoginUserComponent.java
@@ -21,24 +21,30 @@ public class LoginUserComponent {
     private final SessionRepository<? extends Session> sessionRepository;
 
     public Long getMemberId(HttpServletRequest request) {
-        return getMemberSession(request).getMemberId();
-    }
-
-    private MemberSession getMemberSession(HttpServletRequest request) {
         String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         Session session = extractSessionFromHeader(header);
-        return session.getAttribute(SessionConstants.AUTH_SESSION);
+        if (session == null) {
+            throw new UnAuthorizedException(String.format("잘못된 세션입니다 (%s)", header));
+        }
+        MemberSession memberSession = session.getAttribute(SessionConstants.AUTH_SESSION);
+        return memberSession.getMemberId();
+    }
+
+    public Long getMemberIdIfExists(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        Session session = extractSessionFromHeader(header);
+        if (session == null) {
+            return null;
+        }
+        MemberSession memberSession = session.getAttribute(SessionConstants.AUTH_SESSION);
+        return memberSession.getMemberId();
     }
 
     private Session extractSessionFromHeader(String header) {
         if (StringUtils.hasText(header) && header.startsWith(BEARER_TOKEN)) {
-            Session session = sessionRepository.findById(header.split(BEARER_TOKEN)[1]);
-            if (session == null) {
-                throw new UnAuthorizedException(String.format("잘못된 세션입니다 (%s)", header));
-            }
-            return session;
+            return sessionRepository.findById(header.split(BEARER_TOKEN)[1]);
         }
-        throw new UnAuthorizedException(String.format("잘못된 세션입니다 (%s)", header));
+        return null;
     }
 
 }

--- a/potato-api/src/main/java/com/potato/api/controller/board/organization/OrganizationBoardRetrieveController.java
+++ b/potato-api/src/main/java/com/potato/api/controller/board/organization/OrganizationBoardRetrieveController.java
@@ -1,5 +1,7 @@
 package com.potato.api.controller.board.organization;
 
+import com.potato.api.config.argumentResolver.MemberId;
+import com.potato.api.config.interceptor.auth.Auth;
 import com.potato.api.controller.ApiResponse;
 import com.potato.domain.domain.board.organization.repository.dto.BoardWithOrganizationDto;
 import com.potato.api.service.board.organization.OrganizationBoardRetrieveService;
@@ -8,11 +10,14 @@ import com.potato.api.service.board.organization.dto.response.OrganizationBoardI
 import com.potato.api.service.board.organization.dto.response.OrganizationBoardInfoResponseWithImage;
 import com.potato.api.service.board.organization.dto.response.OrganizationBoardWithCreatorInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
+
+import static com.potato.api.config.interceptor.auth.Auth.Role.OPTIONAL_LOGIN;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,10 +25,11 @@ public class OrganizationBoardRetrieveController {
 
     private final OrganizationBoardRetrieveService organizationBoardRetrieveService;
 
-    @Operation(summary = "특정 그룹 게시물을 조회하는 API")
+    @Operation(summary = "특정 그룹 게시물을 조회하는 API", security = {@SecurityRequirement(name = "BearerKey")})
+    @Auth(role = OPTIONAL_LOGIN)
     @GetMapping("/api/v2/organization/board")
-    public ApiResponse<OrganizationBoardWithCreatorInfoResponse> retrieveBoardWithOrganizationAndCreator(@RequestParam Long organizationBoardId) {
-        return ApiResponse.success(organizationBoardRetrieveService.retrieveBoardWithOrganizationAndCreator(organizationBoardId));
+    public ApiResponse<OrganizationBoardWithCreatorInfoResponse> retrieveBoardWithOrganizationAndCreator(@RequestParam Long organizationBoardId, @MemberId Long memberId) {
+        return ApiResponse.success(organizationBoardRetrieveService.retrieveBoardWithOrganizationAndCreator(organizationBoardId, memberId));
     }
 
     @Operation(summary = "전체 그룹 게시물을 스크롤 페이지네이션 기반으로 조회하는 API")

--- a/potato-api/src/main/java/com/potato/api/controller/comment/BoardCommentController.java
+++ b/potato-api/src/main/java/com/potato/api/controller/comment/BoardCommentController.java
@@ -3,7 +3,8 @@ package com.potato.api.controller.comment;
 import com.potato.api.config.argumentResolver.MemberId;
 import com.potato.api.config.interceptor.auth.Auth;
 import com.potato.api.controller.ApiResponse;
-import com.potato.domain.domain.board.BoardType;
+import com.potato.api.service.comment.dto.request.DeleteBoardCommentRequest;
+import com.potato.api.service.comment.dto.request.RetrieveBoardCommentsRequest;
 import com.potato.api.service.comment.BoardCommentService;
 import com.potato.api.service.comment.dto.request.AddBoardCommentRequest;
 import com.potato.api.service.comment.dto.request.LikeBoardCommentRequest;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 import java.util.List;
+
+import static com.potato.api.config.interceptor.auth.Auth.Role.OPTIONAL_LOGIN;
 
 @RequiredArgsConstructor
 @RestController
@@ -32,10 +35,11 @@ public class BoardCommentController {
         return ApiResponse.OK;
     }
 
-    @Operation(summary = "게시물의 댓글 리스트를 조회합니다.")
+    @Operation(summary = "게시물의 댓글 리스트를 조회합니다.", security = {@SecurityRequirement(name = "BearerKey")})
+    @Auth(role = OPTIONAL_LOGIN)
     @GetMapping("/api/v2/board/comment/list")
-    public ApiResponse<List<BoardCommentResponse>> retrieveBoardComments(@RequestParam BoardType type, @RequestParam Long boardId) {
-        return ApiResponse.success(boardCommentService.retrieveBoardCommentList(type, boardId));
+    public ApiResponse<List<BoardCommentResponse>> retrieveBoardComments(@Valid RetrieveBoardCommentsRequest request, @MemberId Long memberId) {
+        return ApiResponse.success(boardCommentService.retrieveBoardCommentList(request, memberId));
     }
 
     @Operation(summary = "게시물의 댓글을 수정합니다.", security = {@SecurityRequirement(name = "BearerKey")})
@@ -49,8 +53,8 @@ public class BoardCommentController {
     @Operation(summary = "작성한 댓글을 삭제합니다.", security = {@SecurityRequirement(name = "BearerKey")})
     @Auth
     @DeleteMapping("/api/v2/board/comment")
-    public ApiResponse<String> deleteBoardComment(@RequestParam Long boardCommentId, @MemberId Long memberId) {
-        boardCommentService.deleteBoardComment(boardCommentId, memberId);
+    public ApiResponse<String> deleteBoardComment(@Valid DeleteBoardCommentRequest request, @MemberId Long memberId) {
+        boardCommentService.deleteBoardComment(request, memberId);
         return ApiResponse.OK;
     }
 

--- a/potato-api/src/main/java/com/potato/api/controller/organization/OrganizationController.java
+++ b/potato-api/src/main/java/com/potato/api/controller/organization/OrganizationController.java
@@ -19,6 +19,7 @@ import javax.validation.Valid;
 
 import java.util.List;
 
+import static com.potato.api.config.interceptor.auth.Auth.Role.OPTIONAL_LOGIN;
 import static com.potato.api.config.interceptor.auth.Auth.Role.ORGANIZATION_MEMBER;
 
 @RequiredArgsConstructor
@@ -35,10 +36,11 @@ public class OrganizationController {
         return ApiResponse.success(organizationService.createOrganization(request, memberId));
     }
 
-    @Operation(summary = "특정 그룹의 정보를 조회하는 API")
+    @Auth(role = OPTIONAL_LOGIN)
+    @Operation(summary = "특정 그룹의 정보를 조회하는 API", security = {@SecurityRequirement(name = "BearerKey")})
     @GetMapping("/api/v1/organization/{subDomain}")
-    public ApiResponse<OrganizationWithMembersInfoResponse> getDetailOrganizationInfo(@PathVariable String subDomain) {
-        return ApiResponse.success(organizationRetrieveService.getDetailOrganizationInfo(subDomain));
+    public ApiResponse<OrganizationWithMembersInfoResponse> getDetailOrganizationInfo(@PathVariable String subDomain, @MemberId Long memberId) {
+        return ApiResponse.success(organizationRetrieveService.getDetailOrganizationInfo(subDomain, memberId));
     }
 
     @Operation(summary = "등록된 그룹 리스트를 불러오는 API")

--- a/potato-api/src/main/java/com/potato/api/controller/organization/OrganizationController.java
+++ b/potato-api/src/main/java/com/potato/api/controller/organization/OrganizationController.java
@@ -36,8 +36,8 @@ public class OrganizationController {
         return ApiResponse.success(organizationService.createOrganization(request, memberId));
     }
 
-    @Auth(role = OPTIONAL_LOGIN)
     @Operation(summary = "특정 그룹의 정보를 조회하는 API", security = {@SecurityRequirement(name = "BearerKey")})
+    @Auth(role = OPTIONAL_LOGIN)
     @GetMapping("/api/v1/organization/{subDomain}")
     public ApiResponse<OrganizationWithMembersInfoResponse> getDetailOrganizationInfo(@PathVariable String subDomain, @MemberId Long memberId) {
         return ApiResponse.success(organizationRetrieveService.getDetailOrganizationInfo(subDomain, memberId));

--- a/potato-api/src/main/java/com/potato/api/service/board/organization/OrganizationBoardRetrieveService.java
+++ b/potato-api/src/main/java/com/potato/api/service/board/organization/OrganizationBoardRetrieveService.java
@@ -37,12 +37,12 @@ public class OrganizationBoardRetrieveService {
     private final BoardImageRepository boardImageRepository;
 
     @Transactional(readOnly = true)
-    public OrganizationBoardWithCreatorInfoResponse retrieveBoardWithOrganizationAndCreator(Long organizationBoardId) {
+    public OrganizationBoardWithCreatorInfoResponse retrieveBoardWithOrganizationAndCreator(Long organizationBoardId, Long memberId) {
         OrganizationBoard organizationBoard = OrganizationBoardServiceUtils.findOrganizationBoardById(organizationBoardRepository, organizationBoardId);
         Organization organization = OrganizationServiceUtils.findOrganizationBySubDomain(organizationRepository, organizationBoard.getSubDomain());
         Member creator = MemberServiceUtils.findMemberById(memberRepository, organizationBoard.getMemberId());
         List<String> imageUrlList = OrganizationBoardServiceUtils.findOrganizationBoardImage(boardImageRepository, organizationBoard.getId());
-        return OrganizationBoardWithCreatorInfoResponse.of(organizationBoard, organization, creator, getBoardHashTags(organizationBoard.getId()), imageUrlList);
+        return OrganizationBoardWithCreatorInfoResponse.of(organizationBoard, organization, creator, getBoardHashTags(organizationBoard.getId()), imageUrlList, organizationBoard.hasLike(memberId));
     }
 
     private List<String> getBoardHashTags(Long boardId) {

--- a/potato-api/src/main/java/com/potato/api/service/board/organization/dto/response/OrganizationBoardWithCreatorInfoResponse.java
+++ b/potato-api/src/main/java/com/potato/api/service/board/organization/dto/response/OrganizationBoardWithCreatorInfoResponse.java
@@ -25,22 +25,27 @@ public class OrganizationBoardWithCreatorInfoResponse extends BaseTimeResponse {
 
     private List<String> imageUrlList;
 
+    private Boolean isLike;
+
     @Builder
-    private OrganizationBoardWithCreatorInfoResponse(OrganizationBoardInfoResponse board, OrganizationInfoResponse organization, MemberInfoResponse creator, List<String> hashTags, List<String> imageUrlList) {
+    private OrganizationBoardWithCreatorInfoResponse(OrganizationBoardInfoResponse board, OrganizationInfoResponse organization,
+                                                     MemberInfoResponse creator, List<String> hashTags, List<String> imageUrlList, boolean isLike) {
         this.board = board;
         this.organization = organization;
         this.creator = creator;
         this.hashTags = hashTags;
         this.imageUrlList = imageUrlList;
+        this.isLike = isLike;
     }
 
-    public static OrganizationBoardWithCreatorInfoResponse of(OrganizationBoard organizationBoard, Organization organization, Member creator, List<String> hashTags, List<String> imageUrlList) {
+    public static OrganizationBoardWithCreatorInfoResponse of(OrganizationBoard organizationBoard, Organization organization, Member creator, List<String> hashTags, List<String> imageUrlList, boolean isLike) {
         OrganizationBoardWithCreatorInfoResponse response = OrganizationBoardWithCreatorInfoResponse.builder()
             .board(OrganizationBoardInfoResponse.of(organizationBoard))
             .organization(OrganizationInfoResponse.of(organization))
             .creator(MemberInfoResponse.of(creator))
             .hashTags(hashTags)
             .imageUrlList(imageUrlList)
+            .isLike(isLike)
             .build();
         response.setBaseTime(organizationBoard);
         return response;

--- a/potato-api/src/main/java/com/potato/api/service/comment/BoardCommentService.java
+++ b/potato-api/src/main/java/com/potato/api/service/comment/BoardCommentService.java
@@ -1,11 +1,12 @@
 package com.potato.api.service.comment;
 
+import com.potato.api.service.comment.dto.request.DeleteBoardCommentRequest;
 import com.potato.api.service.comment.dto.request.LikeBoardCommentRequest;
+import com.potato.api.service.comment.dto.request.RetrieveBoardCommentsRequest;
 import com.potato.domain.domain.board.admin.AdminBoardRepository;
 import com.potato.domain.domain.board.organization.OrganizationBoardRepository;
 import com.potato.domain.domain.comment.BoardComment;
 import com.potato.domain.domain.comment.BoardCommentRepository;
-import com.potato.domain.domain.board.BoardType;
 import com.potato.api.service.comment.dto.request.AddBoardCommentRequest;
 import com.potato.api.service.comment.dto.request.UpdateBoardCommentRequest;
 import com.potato.api.service.comment.dto.response.BoardCommentResponse;
@@ -36,11 +37,11 @@ public class BoardCommentService {
     }
 
     @Transactional(readOnly = true)
-    public List<BoardCommentResponse> retrieveBoardCommentList(BoardType type, Long boardId) {
-        BoardCommentServiceUtils.validateExistBoard(organizationBoardRepository, adminBoardRepository, type, boardId);
-        List<BoardComment> rootComments = boardCommentRepository.findRootCommentByTypeAndBoardId(type, boardId);
+    public List<BoardCommentResponse> retrieveBoardCommentList(RetrieveBoardCommentsRequest request, Long memberId) {
+        BoardCommentServiceUtils.validateExistBoard(organizationBoardRepository, adminBoardRepository, request.getType(), request.getBoardId());
+        List<BoardComment> rootComments = boardCommentRepository.findRootCommentByTypeAndBoardId(request.getType(), request.getBoardId());
         return rootComments.stream()
-            .map(BoardCommentResponse::of)
+            .map(boardComment -> BoardCommentResponse.of(boardComment, memberId))
             .collect(Collectors.toList());
     }
 
@@ -51,8 +52,8 @@ public class BoardCommentService {
     }
 
     @Transactional
-    public void deleteBoardComment(Long boardCommentId, Long memberId) {
-        BoardComment comment = BoardCommentServiceUtils.findBoardCommentByIdAndMemberId(boardCommentRepository, boardCommentId, memberId);
+    public void deleteBoardComment(DeleteBoardCommentRequest request, Long memberId) {
+        BoardComment comment = BoardCommentServiceUtils.findBoardCommentByIdAndMemberId(boardCommentRepository, request.getBoardCommentId(), memberId);
         comment.delete();
     }
 

--- a/potato-api/src/main/java/com/potato/api/service/comment/dto/request/DeleteBoardCommentRequest.java
+++ b/potato-api/src/main/java/com/potato/api/service/comment/dto/request/DeleteBoardCommentRequest.java
@@ -1,0 +1,21 @@
+package com.potato.api.service.comment.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeleteBoardCommentRequest {
+
+    private Long boardCommentId;
+
+    public static DeleteBoardCommentRequest testInstance(Long boardCommentId) {
+        return new DeleteBoardCommentRequest(boardCommentId);
+    }
+
+}

--- a/potato-api/src/main/java/com/potato/api/service/comment/dto/request/RetrieveBoardCommentsRequest.java
+++ b/potato-api/src/main/java/com/potato/api/service/comment/dto/request/RetrieveBoardCommentsRequest.java
@@ -1,0 +1,28 @@
+package com.potato.api.service.comment.dto.request;
+
+import com.potato.domain.domain.board.BoardType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.validation.constraints.NotNull;
+
+@ToString
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RetrieveBoardCommentsRequest {
+
+    @NotNull
+    private BoardType type;
+
+    @NotNull
+    private Long boardId;
+
+    public static RetrieveBoardCommentsRequest testInstance(BoardType type, Long boardId) {
+        return new RetrieveBoardCommentsRequest(type, boardId);
+    }
+
+}

--- a/potato-api/src/main/java/com/potato/api/service/organization/OrganizationRetrieveService.java
+++ b/potato-api/src/main/java/com/potato/api/service/organization/OrganizationRetrieveService.java
@@ -22,9 +22,9 @@ public class OrganizationRetrieveService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public OrganizationWithMembersInfoResponse getDetailOrganizationInfo(String subDomain) {
+    public OrganizationWithMembersInfoResponse getDetailOrganizationInfo(String subDomain, Long memberId) {
         Organization organization = OrganizationServiceUtils.findOrganizationBySubDomain(organizationRepository, subDomain);
-        return OrganizationWithMembersInfoResponse.of(organization, memberRepository.findAllById(organization.getMemberIds()));
+        return OrganizationWithMembersInfoResponse.of(organization, memberRepository.findAllById(organization.getMemberIds()), organization.isFollower(memberId));
     }
 
     @Transactional(readOnly = true)

--- a/potato-api/src/main/java/com/potato/api/service/organization/dto/response/OrganizationWithMembersInfoResponse.java
+++ b/potato-api/src/main/java/com/potato/api/service/organization/dto/response/OrganizationWithMembersInfoResponse.java
@@ -18,11 +18,13 @@ public class OrganizationWithMembersInfoResponse {
 
     private final List<MemberInOrganizationResponse> members = new ArrayList<>();
 
-    public static OrganizationWithMembersInfoResponse of(Organization organization, List<Member> memberList) {
+    private Boolean isFollower;
+
+    public static OrganizationWithMembersInfoResponse of(Organization organization, List<Member> memberList, boolean isFollower) {
         List<MemberInOrganizationResponse> memberInOrganizationResponses = memberList.stream()
             .map(member -> MemberInOrganizationResponse.of(member, organization.getRoleOfMember(member.getId())))
             .collect(Collectors.toList());
-        OrganizationWithMembersInfoResponse response = new OrganizationWithMembersInfoResponse(OrganizationInfoResponse.of(organization));
+        OrganizationWithMembersInfoResponse response = new OrganizationWithMembersInfoResponse(OrganizationInfoResponse.of(organization), isFollower);
         response.members.addAll(memberInOrganizationResponses);
         return response;
     }

--- a/potato-api/src/test/java/com/potato/api/controller/ControllerTestUtils.java
+++ b/potato-api/src/test/java/com/potato/api/controller/ControllerTestUtils.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.potato.api.controller.member.MemberMockMvc;
 import com.potato.domain.domain.member.Member;
 import com.potato.domain.domain.member.MemberRepository;
+import com.potato.domain.domain.organization.Organization;
+import com.potato.domain.domain.organization.OrganizationCategory;
+import com.potato.domain.domain.organization.OrganizationCreator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -24,11 +27,14 @@ public abstract class ControllerTestUtils {
 
     protected String token;
 
+    protected Organization organization;
+
     protected void setup() throws Exception {
         memberMockMvc = new MemberMockMvc(mockMvc, objectMapper);
         String email = "potato@gmail.com";
         token = memberMockMvc.getMockMemberToken(email);
         testMember = memberRepository.findMemberByEmail(email);
+        organization = OrganizationCreator.create("potato", "감자", "개발의 감을 잡자", "https://potato.com", OrganizationCategory.NON_APPROVED_CIRCLE);
     }
 
     protected void cleanup() {

--- a/potato-api/src/test/java/com/potato/api/controller/board/OrganizationBoardMockMvc.java
+++ b/potato-api/src/test/java/com/potato/api/controller/board/OrganizationBoardMockMvc.java
@@ -49,10 +49,10 @@ class OrganizationBoardMockMvc {
         );
     }
 
-    public ApiResponse<OrganizationBoardWithCreatorInfoResponse> retrieveOrganizationBoard(Long organizationBoardId, int expectedStatus) throws Exception {
+    public ApiResponse<OrganizationBoardWithCreatorInfoResponse> retrieveOrganizationBoard(Long organizationBoardId, String token, int expectedStatus) throws Exception {
         MockHttpServletRequestBuilder builder = get("/api/v2/organization/board")
             .param("organizationBoardId", String.valueOf(organizationBoardId))
-            .contentType(MediaType.APPLICATION_JSON);
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ".concat(token));
 
         return objectMapper.readValue(
             mockMvc.perform(builder)

--- a/potato-api/src/test/java/com/potato/api/controller/comment/BoardCommentMockMvc.java
+++ b/potato-api/src/test/java/com/potato/api/controller/comment/BoardCommentMockMvc.java
@@ -3,7 +3,7 @@ package com.potato.api.controller.comment;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.potato.api.controller.ApiResponse;
-import com.potato.domain.domain.board.BoardType;
+import com.potato.api.service.comment.dto.request.RetrieveBoardCommentsRequest;
 import com.potato.api.service.comment.dto.request.AddBoardCommentRequest;
 import com.potato.api.service.comment.dto.response.BoardCommentResponse;
 import org.springframework.http.HttpHeaders;
@@ -28,10 +28,11 @@ public class BoardCommentMockMvc {
         this.objectMapper = objectMapper;
     }
 
-    public ApiResponse<List<BoardCommentResponse>> retrieveBoardComments(BoardType type, Long boardId, int expectedStatus) throws Exception {
+    public ApiResponse<List<BoardCommentResponse>> retrieveBoardComments(RetrieveBoardCommentsRequest request, String token, int expectedStatus) throws Exception {
         MockHttpServletRequestBuilder builder = get("/api/v2/board/comment/list")
-            .param("type", String.valueOf(type))
-            .param("boardId", String.valueOf(boardId));
+            .param("type", String.valueOf(request.getType()))
+            .param("boardId", String.valueOf(request.getBoardId()))
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ".concat(token));
 
         return objectMapper.readValue(
             mockMvc.perform(builder)

--- a/potato-api/src/test/java/com/potato/api/controller/organization/OrganizationControllerTest.java
+++ b/potato-api/src/test/java/com/potato/api/controller/organization/OrganizationControllerTest.java
@@ -35,21 +35,10 @@ class OrganizationControllerTest extends ControllerTestUtils {
     @Autowired
     private OrganizationRepository organizationRepository;
 
-    private Organization organization;
-    private String subDomain;
-    private String name;
-    private String description;
-    private String profileUrl;
-
     @BeforeEach
     void setUp() throws Exception {
         super.setup();
         organizationMockMvc = new OrganizationMockMvc(mockMvc, objectMapper);
-        subDomain = "potato";
-        name = "감자";
-        description = "개발의 감을 잡자";
-        profileUrl = "https://profile.com";
-        organization = OrganizationCreator.create(subDomain, name, description, profileUrl, OrganizationCategory.NON_APPROVED_CIRCLE);
     }
 
     @AfterEach
@@ -109,10 +98,10 @@ class OrganizationControllerTest extends ControllerTestUtils {
         organizationRepository.save(organization);
 
         // when
-        ApiResponse<OrganizationWithMembersInfoResponse> response = organizationMockMvc.getDetailOrganizationInfo(subDomain, token, 200);
+        ApiResponse<OrganizationWithMembersInfoResponse> response = organizationMockMvc.getDetailOrganizationInfo(organization.getSubDomain(), token, 200);
 
         // then
-        assertOrganizationInfoResponse(response.getData().getOrganization(), subDomain, name, description, profileUrl, organization.getCategory(), 1);
+        assertOrganizationInfoResponse(response.getData().getOrganization(), organization.getSubDomain(), organization.getName(), organization.getDescription(), organization.getProfileUrl(), organization.getCategory(), 1);
 
         assertThat(response.getData().getMembers()).hasSize(1);
         assertMemberInOrganizationResponse(response.getData().getMembers().get(0), testMember.getId(), testMember.getEmail(),
@@ -127,9 +116,10 @@ class OrganizationControllerTest extends ControllerTestUtils {
         organizationRepository.save(organization);
 
         // when
-        ApiResponse<OrganizationWithMembersInfoResponse> response = organizationMockMvc.getDetailOrganizationInfo(subDomain, token, 200);
+        ApiResponse<OrganizationWithMembersInfoResponse> response = organizationMockMvc.getDetailOrganizationInfo(organization.getSubDomain(), token, 200);
 
         // then
+        System.out.println(response);
         assertThat(response.getData().getIsFollower()).isTrue();
     }
 
@@ -140,20 +130,20 @@ class OrganizationControllerTest extends ControllerTestUtils {
         organizationRepository.save(organization);
 
         // when
-        ApiResponse<OrganizationWithMembersInfoResponse> response = organizationMockMvc.getDetailOrganizationInfo(subDomain, token, 200);
+        ApiResponse<OrganizationWithMembersInfoResponse> response = organizationMockMvc.getDetailOrganizationInfo(organization.getSubDomain(), token, 200);
 
         // then
         assertThat(response.getData().getIsFollower()).isFalse();
     }
 
     @Test
-    void 로그인_하지_않은_유저가_그룹_상세_조회를_하면__401_에러_없이_팔로우하지_않았다고_표시된다() throws Exception {
+    void 로그인_하지_않은_유저가_그룹_상세_조회를_하면_401_에러_없이_팔로우하지_않았다고_표시된다() throws Exception {
         // given
         organization.addAdmin(testMember.getId());
         organizationRepository.save(organization);
 
         // when
-        ApiResponse<OrganizationWithMembersInfoResponse> response = organizationMockMvc.getDetailOrganizationInfo(subDomain, "Wrong Token", 200);
+        ApiResponse<OrganizationWithMembersInfoResponse> response = organizationMockMvc.getDetailOrganizationInfo(organization.getSubDomain(), "Wrong Token", 200);
 
         // then
         assertThat(response.getData().getIsFollower()).isFalse();
@@ -170,7 +160,8 @@ class OrganizationControllerTest extends ControllerTestUtils {
 
         // then
         assertThat(response.getData()).hasSize(1);
-        assertOrganizationInfoResponse(response.getData().get(0), subDomain, name, description, profileUrl, OrganizationCategory.NON_APPROVED_CIRCLE, 1);
+        assertOrganizationInfoResponse(response.getData().get(0), organization.getSubDomain(), organization.getName(),
+            organization.getDescription(), organization.getProfileUrl(), OrganizationCategory.NON_APPROVED_CIRCLE, 1);
     }
 
     @Test
@@ -190,8 +181,10 @@ class OrganizationControllerTest extends ControllerTestUtils {
 
         // then
         assertThat(response.getData()).hasSize(2);
-        assertOrganizationInfoResponse(response.getData().get(0), subDomain, name, description, profileUrl, OrganizationCategory.NON_APPROVED_CIRCLE, 1);
-        assertOrganizationInfoResponse(response.getData().get(1), organization2.getSubDomain(), organization2.getName(), organization2.getDescription(), organization2.getProfileUrl(), OrganizationCategory.NON_APPROVED_CIRCLE, 1);
+        assertOrganizationInfoResponse(response.getData().get(0), organization.getSubDomain(), organization.getName(),
+            organization.getDescription(), organization.getProfileUrl(), OrganizationCategory.NON_APPROVED_CIRCLE, 1);
+        assertOrganizationInfoResponse(response.getData().get(1), organization2.getSubDomain(), organization2.getName(),
+            organization2.getDescription(), organization2.getProfileUrl(), OrganizationCategory.NON_APPROVED_CIRCLE, 1);
     }
 
     @Test
@@ -205,7 +198,8 @@ class OrganizationControllerTest extends ControllerTestUtils {
 
         // then
         assertThat(response.getData()).hasSize(1);
-        assertOrganizationInfoResponse(response.getData().get(0), subDomain, name, description, profileUrl, OrganizationCategory.NON_APPROVED_CIRCLE, 1);
+        assertOrganizationInfoResponse(response.getData().get(0), organization.getSubDomain(), organization.getName(),
+            organization.getDescription(), organization.getProfileUrl(), OrganizationCategory.NON_APPROVED_CIRCLE, 1);
     }
 
     @Test
@@ -215,7 +209,7 @@ class OrganizationControllerTest extends ControllerTestUtils {
         organizationRepository.save(organization);
 
         //when
-        ApiResponse<String> response = organizationMockMvc.applyJoiningOrganization(subDomain, token, 200);
+        ApiResponse<String> response = organizationMockMvc.applyJoiningOrganization(organization.getSubDomain(), token, 200);
 
         //then
         assertThat(response.getData()).isEqualTo("OK");
@@ -229,7 +223,7 @@ class OrganizationControllerTest extends ControllerTestUtils {
         organizationRepository.save(organization);
 
         // when
-        ApiResponse<String> response = organizationMockMvc.cancelJoiningOrganization(subDomain, token, 200);
+        ApiResponse<String> response = organizationMockMvc.cancelJoiningOrganization(organization.getSubDomain(), token, 200);
 
         // then
         assertThat(response.getData()).isEqualTo("OK");
@@ -243,7 +237,7 @@ class OrganizationControllerTest extends ControllerTestUtils {
         organizationRepository.save(organization);
 
         // when
-        ApiResponse<String> response = organizationMockMvc.leaveFromOrganization(subDomain, token, 200);
+        ApiResponse<String> response = organizationMockMvc.leaveFromOrganization(organization.getSubDomain(), token, 200);
 
         // then
         assertThat(response.getData()).isEqualTo("OK");
@@ -256,7 +250,7 @@ class OrganizationControllerTest extends ControllerTestUtils {
         organizationRepository.save(organization);
 
         //when
-        ApiResponse<String> response = organizationMockMvc.leaveFromOrganization(subDomain, token, 403);
+        ApiResponse<String> response = organizationMockMvc.leaveFromOrganization(organization.getSubDomain(), token, 403);
 
         //then
         assertThat(response.getCode()).isEqualTo(ErrorCode.FORBIDDEN_EXCEPTION.getCode());

--- a/potato-api/src/test/java/com/potato/api/controller/organization/OrganizationMockMvc.java
+++ b/potato-api/src/test/java/com/potato/api/controller/organization/OrganizationMockMvc.java
@@ -47,8 +47,9 @@ class OrganizationMockMvc {
         );
     }
 
-    public ApiResponse<OrganizationWithMembersInfoResponse> getDetailOrganizationInfo(String subDomain, int expectedStatus) throws Exception {
-        MockHttpServletRequestBuilder builder = get("/api/v1/organization/" + subDomain);
+    public ApiResponse<OrganizationWithMembersInfoResponse> getDetailOrganizationInfo(String subDomain, String token, int expectedStatus) throws Exception {
+        MockHttpServletRequestBuilder builder = get("/api/v1/organization/" + subDomain)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ".concat(token));
         return objectMapper.readValue(
             mockMvc.perform(builder)
                 .andExpect(status().is(expectedStatus))

--- a/potato-api/src/test/java/com/potato/api/service/comment/BoardCommentServiceTest.java
+++ b/potato-api/src/test/java/com/potato/api/service/comment/BoardCommentServiceTest.java
@@ -1,6 +1,8 @@
 package com.potato.api.service.comment;
 
+import com.potato.api.service.comment.dto.request.DeleteBoardCommentRequest;
 import com.potato.api.service.comment.dto.request.LikeBoardCommentRequest;
+import com.potato.api.service.comment.dto.request.RetrieveBoardCommentsRequest;
 import com.potato.domain.domain.board.BoardType;
 import com.potato.domain.domain.board.admin.AdminBoard;
 import com.potato.domain.domain.board.admin.AdminBoardCreator;
@@ -198,8 +200,10 @@ class BoardCommentServiceTest extends OrganizationMemberSetUpTest {
         rootComment2.addChildComment(memberId, "자식 댓글2-1");
         boardCommentRepository.saveAll(Arrays.asList(rootComment1, rootComment2));
 
+        RetrieveBoardCommentsRequest request = RetrieveBoardCommentsRequest.testInstance(type, organizationBoard.getId());
+
         // when
-        List<BoardCommentResponse> responses = boardCommentService.retrieveBoardCommentList(type, organizationBoard.getId());
+        List<BoardCommentResponse> responses = boardCommentService.retrieveBoardCommentList(request, memberId);
 
         // then
         assertThat(responses).hasSize(2);
@@ -228,8 +232,10 @@ class BoardCommentServiceTest extends OrganizationMemberSetUpTest {
         rootComment2.addChildComment(memberId, "자식 댓글2-1");
         boardCommentRepository.saveAll(Arrays.asList(rootComment1, rootComment2));
 
+        RetrieveBoardCommentsRequest request = RetrieveBoardCommentsRequest.testInstance(type, adminBoard.getId());
+
         // when
-        List<BoardCommentResponse> responses = boardCommentService.retrieveBoardCommentList(type, adminBoard.getId());
+        List<BoardCommentResponse> responses = boardCommentService.retrieveBoardCommentList(request, memberId);
 
         // then
         assertThat(responses).hasSize(2);
@@ -254,14 +260,19 @@ class BoardCommentServiceTest extends OrganizationMemberSetUpTest {
         BoardComment rootComment1 = BoardCommentCreator.createRootComment(BoardType.ORGANIZATION_BOARD, organizationBoard.getId(), memberId, "부모 댓글1");
         boardCommentRepository.save(rootComment1);
 
+        RetrieveBoardCommentsRequest request = RetrieveBoardCommentsRequest.testInstance(BoardType.ADMIN_BOARD, 999L);
+
         // when & then
-        assertThatThrownBy(() -> boardCommentService.retrieveBoardCommentList(BoardType.ADMIN_BOARD, 999L)).isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> boardCommentService.retrieveBoardCommentList(request, memberId)).isInstanceOf(NotFoundException.class);
     }
 
     @Test
     void 존재하지_않는_게시물의_댓글을_불러올_수_없다() {
+        // given
+        RetrieveBoardCommentsRequest request = RetrieveBoardCommentsRequest.testInstance(BoardType.ADMIN_BOARD, 999L);
+
         // when & then
-        assertThatThrownBy(() -> boardCommentService.retrieveBoardCommentList(BoardType.ADMIN_BOARD, 999L)).isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> boardCommentService.retrieveBoardCommentList(request, memberId)).isInstanceOf(NotFoundException.class);
     }
 
     @Test
@@ -293,8 +304,10 @@ class BoardCommentServiceTest extends OrganizationMemberSetUpTest {
         BoardComment comment = BoardCommentCreator.createRootComment(type, organizationBoard.getId(), memberId, "댓글");
         boardCommentRepository.save(comment);
 
+        DeleteBoardCommentRequest request = DeleteBoardCommentRequest.testInstance(comment.getId());
+
         // when
-        boardCommentService.deleteBoardComment(comment.getId(), memberId);
+        boardCommentService.deleteBoardComment(request, memberId);
 
         // then
         List<BoardComment> boardCommentList = boardCommentRepository.findAll();
@@ -310,8 +323,10 @@ class BoardCommentServiceTest extends OrganizationMemberSetUpTest {
         BoardComment comment = BoardCommentCreator.createRootComment(BoardType.ORGANIZATION_BOARD, organizationBoard.getId(), memberId, "댓글");
         boardCommentRepository.save(comment);
 
+        DeleteBoardCommentRequest request = DeleteBoardCommentRequest.testInstance(comment.getId());
+
         // when & then
-        assertThatThrownBy(() -> boardCommentService.deleteBoardComment(comment.getId(), 999L)).isInstanceOf(NotFoundException.class);
+        assertThatThrownBy(() -> boardCommentService.deleteBoardComment(request, 999L)).isInstanceOf(NotFoundException.class);
     }
 
     @Test
@@ -323,8 +338,10 @@ class BoardCommentServiceTest extends OrganizationMemberSetUpTest {
         comment.delete();
         boardCommentRepository.save(comment);
 
+        RetrieveBoardCommentsRequest request = RetrieveBoardCommentsRequest.testInstance(type, organizationBoard.getId());
+
         // when
-        List<BoardCommentResponse> responses = boardCommentService.retrieveBoardCommentList(type, organizationBoard.getId());
+        List<BoardCommentResponse> responses = boardCommentService.retrieveBoardCommentList(request, memberId);
 
         // then
         assertThat(responses).hasSize(1);

--- a/potato-api/src/test/java/com/potato/api/service/organization/OrganizationRetrieveServiceTest.java
+++ b/potato-api/src/test/java/com/potato/api/service/organization/OrganizationRetrieveServiceTest.java
@@ -52,7 +52,7 @@ class OrganizationRetrieveServiceTest extends MemberSetupTest {
         organizationRepository.save(organization);
 
         // when
-        OrganizationWithMembersInfoResponse response = organizationRetrieveService.getDetailOrganizationInfo(subDomain);
+        OrganizationWithMembersInfoResponse response = organizationRetrieveService.getDetailOrganizationInfo(subDomain, memberId);
 
         // then
         assertThat(response.getMembers()).hasSize(1);
@@ -63,7 +63,7 @@ class OrganizationRetrieveServiceTest extends MemberSetupTest {
     void 특정_그룹을_조회시_해당하는_그룹이_없는경우() {
         // when & then
         assertThatThrownBy(
-            () -> organizationRetrieveService.getDetailOrganizationInfo(subDomain)
+            () -> organizationRetrieveService.getDetailOrganizationInfo(subDomain, memberId)
         ).isInstanceOf(NotFoundException.class);
     }
 

--- a/potato-domain/src/main/java/com/potato/domain/domain/board/organization/OrganizationBoard.java
+++ b/potato-domain/src/main/java/com/potato/domain/domain/board/organization/OrganizationBoard.java
@@ -71,7 +71,7 @@ public class OrganizationBoard extends BaseTimeEntity {
     }
 
     public void addLike(Long memberId) {
-        if (hasAlreadyLike(memberId)) {
+        if (hasLike(memberId)) {
             throw new ConflictException(String.format("이미 멤버 (%s)는 게시물 (%s)에 좋아요를 눌렀습니다", memberId, this.id));
         }
         OrganizationBoardLike like = OrganizationBoardLike.of(this, memberId);
@@ -79,7 +79,7 @@ public class OrganizationBoard extends BaseTimeEntity {
         this.likesCount++;
     }
 
-    private boolean hasAlreadyLike(Long memberId) {
+    public boolean hasLike(Long memberId) {
         return this.organizationBoardLikeList.stream()
             .anyMatch(boardLike -> boardLike.isSameEntity(memberId));
     }

--- a/potato-domain/src/main/java/com/potato/domain/domain/comment/BoardComment.java
+++ b/potato-domain/src/main/java/com/potato/domain/domain/comment/BoardComment.java
@@ -93,7 +93,7 @@ public class BoardComment extends BaseTimeEntity {
     }
 
     public void addLike(Long memberId) {
-        if (alreadyLike(memberId)) {
+        if (isLike(memberId)) {
             throw new ConflictException(String.format("멤버 (%s)는 (%s) 댓글에 좋아요를 누른 상태입니다.", memberId, this.id));
         }
         validateNotDeletedBoardComment();
@@ -102,7 +102,7 @@ public class BoardComment extends BaseTimeEntity {
         this.commentLikeCounts++;
     }
 
-    private boolean alreadyLike(Long memberId) {
+    public boolean isLike(Long memberId) {
         return this.boardCommentLikeList.stream()
             .anyMatch(boardCommentLike -> boardCommentLike.isSameMember(memberId));
     }

--- a/potato-domain/src/main/java/com/potato/domain/domain/organization/Organization.java
+++ b/potato-domain/src/main/java/com/potato/domain/domain/organization/Organization.java
@@ -124,14 +124,14 @@ public class Organization extends BaseTimeEntity {
     }
 
     public void addFollow(Long memberId) {
-        if (hasAlreadyFollow(memberId)) {
+        if (isFollower(memberId)) {
             throw new ConflictException(String.format("이미 멤버 (%s)는 그룹 (%s)에 팔로우를 했습니다", memberId, this.subDomain));
         }
         this.organizationFollowerList.add(OrganizationFollower.newFollow(this, memberId));
         this.followersCount++;
     }
 
-    private boolean hasAlreadyFollow(Long memberId) {
+    public boolean isFollower(Long memberId) {
         return this.organizationFollowerList.stream()
             .anyMatch(follow -> follow.isSameMember(memberId));
     }


### PR DESCRIPTION
- [x] 그룹 상세 조회시, 팔로우를 했는지 필드 추가.
- [x] 특정 그룹의 게시물을 조회할 때 좋아요 여부 필드 추가.
- [x] 특정 게시물의 댓글들을 조회할 떄 좋아요 여부 필드 추가.

비 로그인시 false
로그인 했는데, 좋아요 & 팔로우 한 경우 true
로그인 했는데 좋아요 & 팔로우 하지 않은 경우 false